### PR TITLE
Add release post and update download page for tDiary 5.5.0

### DIFF
--- a/_posts/2026-07-24-release-5_5_0.md
+++ b/_posts/2026-07-24-release-5_5_0.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: tDiary-5.5.0 リリース
+categories:
+  - release
+  - 5.5
+---
+
+29の日ではありませんが、tDiary 5.5.0 をリリースします。約1年1ヶ月ぶりのリリースです。今回は CGI クラスへの依存の廃止という、内部構造の大きな書き換えを含むリリースです。
+
+## 本体(tdiary-core)の変更点
+* CGI クラスへの依存を廃止し、内部の処理を Rack ベースの TDiary::Request に統一(Ruby 4.0 で縮小される cgi ライブラリへの対応)
+* CGI と FastCGI のエントリポイントを Rack アダプタとして書き換え
+* Amazon プラグインの PA-API 5.0 OffersV2 対応と、403 が返された場合の amazon.co.jp の URL 表示
+* 日記編集欄のサイズ調整を JavaScript から CSS へ変更
+* プラグインのインスタンスキャッシュを追加(オプトイン)
+* フル版 tarball に同梱する gem を pure Ruby のもののみに変更
+* Heroku 向けの依存を bundler のオプショナルなグループへ移動
+* tdiary gem を Trusted Publishing でリリースするように変更
+
+## theme (tdiary-theme)の変更点
+* とくになし
+
+## blogkit (tdiary-blogkit)の変更点
+* とくになし
+
+## contrib (tdiary-contrib)の変更点
+* oEmbed で取得した埋め込み用 HTML を日記に挿入する oembed プラグインを追加
+* Google Analytics GA4 プラグインを追加
+* Gyazo プラグインにキャッシュ機能を追加
+* OpenGraph タグ fediverse:creator の出力に対応
+* flickr プラグインから Oga サポートを削除
+* Emacs 用 tdiary-mode を新しい Emacs に対応

--- a/download.md
+++ b/download.md
@@ -4,13 +4,13 @@ title: ダウンロード
 permalink: /download/
 ---
 ### tDiary本体、プラグイン、テーマ
-#### パッケージ版(5.4.0)
+#### パッケージ版(5.5.0)
 
 3ヶ月ごと定期的にリリースされるシリーズです。動作実績を重要視するならこちら。基本セットはtDiary本体のみが含まれています。付属のテーマはデフォルトのものだけです。フルセットには別配布になっているテーマ集がすべて入っています。
 
-* tDiary 5.4.0 (基本セット): [tdiary-v5.4.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.4.0/tdiary-v5.4.0.tar.gz) (約3MB)
-* tDiary 5.4.0 (フルセット): [tdiary-full-v5.4.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.4.0/tdiary-full-v5.4.0.tar.gz) (約7MB)
-* テーマ集 5.4.0: [tdiary-theme-v5.4.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.4.0/tdiary-theme-v5.4.0.tar.gz) (約4MB)
+* tDiary 5.5.0 (基本セット): [tdiary-v5.5.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.5.0/tdiary-v5.5.0.tar.gz) (約2MB)
+* tDiary 5.5.0 (フルセット): [tdiary-full-v5.5.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.5.0/tdiary-full-v5.5.0.tar.gz) (約6MB)
+* テーマ集 5.5.0: [tdiary-theme-v5.5.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.5.0/tdiary-theme-v5.5.0.tar.gz) (約4MB)
 
 #### GitHubによる最新版の取得
 
@@ -30,7 +30,7 @@ permalink: /download/
 
 tDiary 2.0系以降に追加するパッケージとして、BlogKitを提供しています。このキットは、記事を日付単位で管理する日記ツールとしてではなく、Blogツールのようにトピック単位で管理するものに、tDiaryを変更します。また、数々のプラグインにより、いっそうBlogらしさを演出する作りになっています。基本的に、同じバージョンのtDiary本体とともに使うようになっています。異なるバージョンでは動かないものもあります。
 
-*BlogKit(5.4.0): [tdiary-blogkit-v5.4.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.4.0/tdiary-blogkit-v5.4.0.tar.gz) (37KB)
+*BlogKit(5.5.0): [tdiary-blogkit-v5.5.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.5.0/tdiary-blogkit-v5.5.0.tar.gz) (36KB)
 *BlogKitリポジトリ: https://github.com/tdiary/tdiary-blogkit
 
 ### contrib
@@ -43,7 +43,7 @@ contribパッケージには、本体(core)やプラグイン(plugin)パッケ�
 
 最新のcontribパッケージは常に以下から入手できます。
 
-* contrib(5.4.0): [tdiary-contrib-v5.4.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.4.0/tdiary-contrib-v5.4.0.tar.gz) (394KB)
+* contrib(5.5.0): [tdiary-contrib-v5.5.0.tar.gz](https://github.com/tdiary/tdiary-core/releases/download/v5.5.0/tdiary-contrib-v5.5.0.tar.gz) (405KB)
 * contribリポジトリ: https://github.com/tdiary/tdiary-contrib
 
 またcontribは、希望者ならどなたでもcommitできるリポジトリとして運用しています。有用なプラグインやツールを作ったら、遠慮なく追加してください。このリポジトリへ参加するには、まず最初だけGitHub上の自分のリポジトリからpull requestを送ってください。それをもって参加の意思確認とし、teamへ追加します。それ以降は直接公式リポジトリへcommitしてかまいません。


### PR DESCRIPTION
This adds the release announcement post for tDiary 5.5.0 and updates the download page to point at the v5.5.0 release assets. The post follows the same structure as the 5.3.0 and 5.4.0 announcements and summarizes user-visible changes in `tdiary-core` and `tdiary-contrib`. The package sizes on `download.md` reflect the actual v5.5.0 assets. The base tarball shrank to about 2MB and the full tarball to about 6MB because the full tarball now vendors only pure Ruby gems.
