### PR TITLE
Add workflow to update site on tdiary-core release

### DIFF
--- a/.github/scripts/update-release.rb
+++ b/.github/scripts/update-release.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# Update site files for a new tDiary release.
+# Usage: ruby .github/scripts/update-release.rb VERSION DATE
+#   VERSION: new release version (e.g. 5.6.0)
+#   DATE: post date in YYYY-MM-DD (JST)
+
+version, date = ARGV
+abort "usage: #{$0} VERSION DATE" unless version && date
+abort "invalid version: #{version}" unless version.match?(/\A\d+\.\d+\.\d+\z/)
+abort "invalid date: #{date}" unless date.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+
+def replace_version(path, current_pattern, version)
+  content = File.read(path)
+  current = content[current_pattern, 1] or abort "current version not found in #{path}"
+  if current == version
+    puts "#{path}: already #{version}"
+    return
+  end
+  File.write(path, content.gsub(current, version))
+  puts "#{path}: #{current} -> #{version}"
+end
+
+replace_version("download.md", /^#### パッケージ版\((\d+\.\d+\.\d+)\)/, version)
+replace_version("_includes/sidebar.html", %r{<p>(\d+\.\d+\.\d+)</p>}, version)
+
+post = "_posts/#{date}-release-#{version.tr(".", "_")}.md"
+if File.exist?(post)
+  puts "#{post}: already exists, skipped"
+else
+  series = version.split(".").first(2).join(".")
+  File.write(post, <<~POST)
+    ---
+    layout: post
+    title: tDiary-#{version} リリース
+    categories:
+      - release
+      - #{series}
+    ---
+
+    tDiary #{version} をリリースします。
+
+    ## 本体(tdiary-core)の変更点
+    * とくになし
+
+    ## theme (tdiary-theme)の変更点
+    * とくになし
+
+    ## blogkit (tdiary-blogkit)の変更点
+    * とくになし
+
+    ## contrib (tdiary-contrib)の変更点
+    * とくになし
+  POST
+  puts "#{post}: created"
+end

--- a/.github/workflows/tdiary-release.yml
+++ b/.github/workflows/tdiary-release.yml
@@ -1,0 +1,46 @@
+name: Update site for tDiary release
+
+on:
+  repository_dispatch:
+    types: [tdiary-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate payload
+        env:
+          VERSION: ${{ github.event.client_payload.version }}
+          TAG: ${{ github.event.client_payload.tag }}
+        run: |
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'
+          test "$TAG" = "v$VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update download page, sidebar and release post
+        env:
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          DATE=$(TZ=Asia/Tokyo date +%Y-%m-%d)
+          ruby .github/scripts/update-release.rb "$VERSION" "$DATE"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release-${{ github.event.client_payload.version }}
+          title: Update site for tDiary ${{ github.event.client_payload.version }}
+          commit-message: Update site for tDiary ${{ github.event.client_payload.version }}
+          body: |
+            Automated update for the [tDiary ${{ github.event.client_payload.version }} release](https://github.com/tdiary/tdiary-core/releases/tag/${{ github.event.client_payload.tag }}).
+
+            - Update version and download URLs in `download.md`
+            - Update version in `_includes/sidebar.html`
+            - Add a draft release post under `_posts/`
+
+            Please review and edit the release post before merging.


### PR DESCRIPTION
This adds a workflow triggered by `repository_dispatch` (event_type: `tdiary-release`) with `version` and `tag` in `client_payload`, sent from the tdiary-core release workflow. It automates the manual site updates in tdiary/tdiary-core#1238.

The workflow runs `.github/scripts/update-release.rb`, which rewrites the version and download URLs in `download.md`, updates the version in `_includes/sidebar.html`, and generates a draft release post under `_posts/` dated with the JST date. It then opens a PR via `peter-evans/create-pull-request` instead of pushing directly, so the release post can be edited before merging.

The script detects the current version from each file and replaces all its occurrences, so it works even when the two files are at different versions (sidebar is currently at 5.4.0). Re-running is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)